### PR TITLE
render as formatter, not gadget

### DIFF
--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -14,7 +14,7 @@
 
   emit = ($item, item) => {
     return $item.append(`
-    <div data-item="viewer" style="background-color:#eee;padding:15px;">
+    <div data-item="viewer" style="width:98%">
     <graphviz-viewer>${expand(item.text)}</graphviz-viewer>
     </div>`)
   };
@@ -26,8 +26,10 @@
     });
     let viewer = $item.find('graphviz-viewer')
     viewer.dblclick(event => {
-      event.stopPropagation()
-      wiki.dialog('Graphviz', `<div><graphviz-viewer>${expand(item.text)}</graphviz-viewer></div>`)
+      if(event.shiftKey) {
+        event.stopPropagation()
+        wiki.dialog('Graphviz', `<div><graphviz-viewer>${expand(item.text)}</graphviz-viewer></div>`)
+      }
     })
     viewer.get(0).render().then(svg => {
       $(svg).find('.node').click((event)=> {

--- a/factory.json
+++ b/factory.json
@@ -1,5 +1,5 @@
 {
   "name": "Graphviz",
-  "title": "Graphviz Plugin",
-  "category": "other"
+  "title": "Dot Formatted Diagram",
+  "category": "format"
 }


### PR DESCRIPTION
This commit removes the gray border making a bit more room for the diagram.
Without a border double-click now opens the editor.
Now shift-double-click opens magnified dialog, 
(not as useful as could be because node clicks don't open pages)

Sample application:
http://growing.ward.bay.wiki.org/public-space-patterns.html

Improved look as formatting plugin.
![image](https://user-images.githubusercontent.com/12127/52993562-7ff95300-33c9-11e9-9dc6-e511bac18d41.png)


