### PR TITLE
Algorithmic Markup

### DIFF
--- a/client/graphviz-viewer.js
+++ b/client/graphviz-viewer.js
@@ -2,28 +2,6 @@
 
 import Viz from './viz.js/viz.es.js'
 
-
-// const template = document.createElement('template');
-// template.innerHTML = `
-// <style>
-// :host {
-//   display: flex;
-//   flex-flow: row nowrap;
-//   width: 100%;
-//   height: 100%;
-// }
-// </style>
-// <slot></slot>`
-// class WikiLineup extends HTMLElement {
-//   constructor() {
-//     super()
-//     this.attachShadow({ mode: 'open' })
-//     this.shadowRoot.appendChild(template.content.cloneNode(true))
-//   }
-// }
-// customElements.define('wiki-lineup', WikiLineup)
-// export default WikiLineup
-
 const template = document.createElement('template')
 template.innerHTML = `
   <div style="width:80%; padding:8px; color:gray; background-color:#eee; margin:0 auto; text-align:center">

--- a/client/graphviz-viewer.js
+++ b/client/graphviz-viewer.js
@@ -2,10 +2,39 @@
 
 import Viz from './viz.js/viz.es.js'
 
+
+// const template = document.createElement('template');
+// template.innerHTML = `
+// <style>
+// :host {
+//   display: flex;
+//   flex-flow: row nowrap;
+//   width: 100%;
+//   height: 100%;
+// }
+// </style>
+// <slot></slot>`
+// class WikiLineup extends HTMLElement {
+//   constructor() {
+//     super()
+//     this.attachShadow({ mode: 'open' })
+//     this.shadowRoot.appendChild(template.content.cloneNode(true))
+//   }
+// }
+// customElements.define('wiki-lineup', WikiLineup)
+// export default WikiLineup
+
+const template = document.createElement('template')
+template.innerHTML = `
+  <div style="width:80%; padding:8px; color:gray; background-color:#eee; margin:0 auto; text-align:center">
+    <i>drawing diagram</i>
+  </div>`
+
 class GraphvizViewer extends HTMLElement {
   constructor() {
     super()
     this.attachShadow({mode: 'open'})
+    this.shadowRoot.appendChild(template.content.cloneNode(true))
     this.workerURL = new URL('./viz.js/full.render.js', import.meta.url)
   }
 
@@ -17,6 +46,7 @@ class GraphvizViewer extends HTMLElement {
         return self.viz.renderSVGElement(self.decodedHTML())
           .then(svg => {
             svg.setAttribute('style', 'width: 100%; height: auto;')
+            self.shadowRoot.innerHTML = ``
             self.shadowRoot.appendChild(svg)
             return svg
           })

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -78,14 +78,19 @@
           deeper.push({tree:ir, context})
 
         } else if (ir.match(/^[A-Z]/)) {
-          console.log('eval',ir.toString())
+          console.log('eval',ir)
 
           if (ir.match(/^LINKS/)) {
             let text = context.want.map(p=>p.text).join("\n")
             let links = text.match(/\[\[.*?\]\]/g).map(l => l.slice(2,-2))
             let tree = nest()
             links.map((link) => {
-              dot.push(`${quote(context.name)} -> ${quote(link)}`)
+              if (ir.match(/^LINKS HERE -> NODE/)) {
+                dot.push(`${quote(context.name)} -> ${quote(link)}`)
+              }
+              if (ir.match(/^LINKS NODE -> HERE/)) {
+                dot.push(`${quote(context.name)} -> ${quote(link)}`)
+              }
               deeper.push({tree, context:Object.assign({},context,{name:link})})
             })
           }
@@ -94,10 +99,13 @@
             let tree = nest()
             let page = await get(context)
             if (page) {
-              dot.push(quote(context.name))
-              // dot.push(`${quote(e)} -> ${quote(context.name)} [style=dotted]`)
-              newcontext = Object.assign({},context,{page, want:page.story})
-              deeper.push({tree, context:newcontext})
+              if (ir.match(/^HERE NODE/)) {
+                dot.push(quote(context.name))
+              }
+              if (ir.match(/^HERE NODE \w+/)) {
+                dot.push(`${quote(ir)} -> ${quote(context.name)} [style=dotted]`)
+              }
+              deeper.push({tree, context:Object.assign({},context,{page, want:page.story})})
             }
           }
 

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -69,17 +69,18 @@
 
     async function eval(tree, context, dot) {
       let deeper = []
-      for (var pc=0; pc<tree.length; pc++) {
-        let e = tree[pc]
-        const nest = () => (pc+1 < tree.length && Array.isArray(tree[pc+1])) ? tree[++pc] : []
+      var pc = 0
+      while (pc < tree.length) {
+        let ir = tree[pc++]
+        const nest = () => (pc < tree.length && Array.isArray(tree[pc])) ? tree[pc++] : []
 
-        if (Array.isArray(e)) {
-          deeper.push({tree:e, context})
+        if (Array.isArray(ir)) {
+          deeper.push({tree:ir, context})
 
-        } else if (e.match(/^[A-Z]/)) {
-          console.log('eval',e.toString())
+        } else if (ir.match(/^[A-Z]/)) {
+          console.log('eval',ir.toString())
 
-          if (e.match(/^LINKS/)) {
+          if (ir.match(/^LINKS/)) {
             let text = context.want.map(p=>p.text).join("\n")
             let links = text.match(/\[\[.*?\]\]/g).map(l => l.slice(2,-2))
             let tree = nest()
@@ -89,7 +90,7 @@
             })
           }
 
-          if (e.match(/^HERE/)) {
+          if (ir.match(/^HERE/)) {
             let tree = nest()
             let page = await get(context)
             if (page) {
@@ -101,8 +102,8 @@
           }
 
         } else {
-          console.log('eval',e.toString())
-          dot.push(e)
+          console.log('eval',ir.toString())
+          dot.push(ir)
         }
       }
 

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -95,7 +95,7 @@
                 dot.push(`${quote(context.name)} -> ${quote(link)}`)
               }
               if (ir.match(/^LINKS NODE -> HERE/)) {
-                dot.push(`${quote(context.name)} -> ${quote(link)}`)
+                dot.push(`${quote(link)} -> ${quote(context.name)}`)
               }
               deeper.push({tree, context:Object.assign({},context,{name:link})})
             })
@@ -113,6 +113,21 @@
               }
               deeper.push({tree, context:Object.assign({},context,{page, want:page.story})})
             }
+          }
+
+          if (ir.match(/^WHERE/)) {
+            let tree = nest()
+            var want = context.want
+            if (m = ir.match(/\/.*?\//)) {
+              let regex = new RegExp(m[0].slice(1,-1))
+              want = want.filter(item => item.text.match(regex))
+            } else if (m = ir.match(/[a-z_]+/)) {
+              let attr = m[0]
+              debugger
+              want = want.filter(item => item[attr])
+              console.log('want',want)
+            }
+            deeper.push({tree, context:Object.assign({},context,{want})})
           }
 
         } else {

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -20,14 +20,17 @@
       return diagram ($item, item)
     } else if (text.match(/^DOT /)) {
       var root = tree(text.split(/\r?\n/), [], 0)
-      var here = $item.parents('.page').data().data
+      var $page = $item.parents('.page')
+      var here = $page.data('data')
       var context = {
+        graph: 'digraph',
         name: here.title,
+        site: $page.data('site')||location.host,
         page: here,
         want: here.story.slice()
       }
       var dot = await eval(root, context, [])
-      return `digraph {${dot.join("\n")}}`
+      return `${context.graph} {${dot.join("\n")}}`
     } else {
       return text
     }
@@ -60,9 +63,8 @@
       if (context.name == context.page.title) {
         return context.page
       } else {
-        let site = location.host
         let slug = asSlug(context.name)
-        const res = await fetch(`//${site}/${slug}.json`)
+        const res = await fetch(`//${context.site}/${slug}.json`)
         return res.ok ? res.json() : null
       }
     }
@@ -79,6 +81,10 @@
 
         } else if (ir.match(/^[A-Z]/)) {
           console.log('eval',ir)
+
+          if (ir.match(/^DOT (strict )?digraph/)) {
+            context.graph = ir.replace(/DOT /,'')
+          }
 
           if (ir.match(/^LINKS/)) {
             let text = context.want.map(p=>p.text).join("\n")

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -130,6 +130,15 @@
             deeper.push({tree, context:Object.assign({},context,{want})})
           }
 
+          if (ir.match(/^FAKE/)) {
+            if (ir.match(/^FAKE HERE -> NODE/)) {
+              dot.push(`${quote(context.name)} -> ${quote('post-'+context.name)}`)
+            }
+            if (ir.match(/^FAKE NODE -> HERE/)) {
+              dot.push(`${quote('pre-'+context.name)} -> ${quote(context.name)}`)
+            }
+          }
+
         } else {
           console.log('eval',ir.toString())
           dot.push(ir)

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -89,7 +89,7 @@
 
           if (ir.match(/^LINKS/)) {
             let text = context.want.map(p=>p.text).join("\n")
-            let links = text.match(/\[\[.*?\]\]/g).map(l => l.slice(2,-2))
+            let links = (text.match(/\[\[.*?\]\]/g)||[]).map(l => l.slice(2,-2))
             let tree = nest()
             links.map((link) => {
               if (ir.match(/^LINKS HERE -> NODE/)) {
@@ -127,7 +127,7 @@
             var want = context.want
             if (m = ir.match(/\/.*?\//)) {
               let regex = new RegExp(m[0].slice(1,-1))
-              want = want.filter(item => item.text.match(regex))
+              want = want.filter(item => (item.text||'').match(regex))
             } else if (m = ir.match(/[a-z_]+/)) {
               let attr = m[0]
               debugger
@@ -144,6 +144,17 @@
             if (ir.match(/^FAKE NODE -> HERE/)) {
               dot.push(`${quote('pre-'+context.name)} -> ${quote(context.name)}`)
             }
+          }
+
+          if (ir.match(/^LINEUP/)) {
+            let tree = nest()
+            let $page = $item.parents('.page')
+            let $lineup = $(`.page:lt(${$('.page').index($page)})`)
+            $lineup.each((i,p) => {
+              let site = $(p).data('site')||location.host
+              let name = $(p).data('data').title
+              deeper.push({tree, context:Object.assign({},context,{site, name})})
+            })
           }
 
         } else {

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -18,7 +18,7 @@
       return diagram ($item, item)
     } else if (text.match(/^DOT /)) {
       var root = tree(text.split(/\r?\n/), [], 0)
-      var dot = `digraph {${eval(root,['ROOT']).join("\n")}}`
+      var dot = `digraph {${eval(root,'ROOT',[]).join("\n")}}`
       // console.log('dot',dot)
       return dot
     } else {
@@ -49,18 +49,21 @@
       return `"${string.replace(/ +/g,'\n')}"`
     }
 
-    function eval(tree, dot) {
-      let parent = dot[dot.length-1]
+    function eval(tree, parent, dot) {
+      var place = parent
+      let deeper = []
       tree.map ((e) => {
         if (Array.isArray(e)) {
-          eval(e, dot)
+          deeper.push({tree:e, parent:place})
         } else if (e.match(/^[A-Z]/)) {
           dot.push(`${parent} -> ${quote(e)}`)
-          dot.push(quote(e))
+          dot.push(place = quote(e))
         } else {
           dot.push(e)
         }
       })
+      deeper.map ((child) =>
+        eval(child.tree, child.parent, dot))
       return dot
     }
   }

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -32,7 +32,7 @@
         let command = m[2]
         if (spaces == indent) {
           here.push(command)
-          console.log(indent, command)
+          console.log('parse',command)
           lines.shift()
         } else if (spaces > indent) {
           var more = []
@@ -56,9 +56,11 @@
         if (Array.isArray(e)) {
           deeper.push({tree:e, parent:place})
         } else if (e.match(/^[A-Z]/)) {
+          console.log('eval',e.toString())
           dot.push(`${parent} -> ${quote(e)}`)
           dot.push(place = quote(e))
         } else {
+          console.log('eval',e.toString())
           dot.push(e)
         }
       })

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -238,12 +238,14 @@
     let dot = await makedot($item, item)
     $item.find('.viewer').html(`<graphviz-viewer>${dot}</graphviz-viewer>`)
     let $viewer = $item.find('graphviz-viewer')
-    // $viewer.dblclick(event => {
-    //   if(event.shiftKey) {
-    //     event.stopPropagation()
-    //     wiki.dialog('Graphviz', `<div><graphviz-viewer>${expand(item.text)}</graphviz-viewer></div>`)
-    //   }
-    // })
+    $viewer.dblclick(event => {
+      if(event.shiftKey) {
+        event.stopPropagation()
+        let svg = $item.find('graphviz-viewer').get(0)
+            .shadowRoot.querySelector('svg').cloneNode(true)
+        wiki.dialog('Graphviz', svg)
+      }
+    })
     $viewer.get(0).render().then(svg => {
       $(svg).find('.node').click((event)=> {
         event.stopPropagation()

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -12,10 +12,60 @@
       .replace(/\*(.+?)\*/g, '<i>$1</i>');
   };
 
+  async function diagram ($item, item) {
+    let $page = $item.parents('.page')
+    let site = $page.data('site')||location.host
+    let slug = $page.attr('id')
+    // return `digraph {"${site}"->"${slug}"}`
+
+    const get = (url) => fetch(url).then(res => res.json())
+    const quote = (string) => `"${string.replace(/ +/g,'\n')}"`
+    const asSlug = (name) => name.replace(/\s/g, '-').replace(/[^A-Za-z0-9-]/g, '').toLowerCase()
+    const node = (title,color) => `${quote(title)} [fillcolor=${sites[asSlug(title)]?color:'lightgray'}]`
+    var sites = {}, sitemap = await get(`http://${site}/system/sitemap.json`)
+    sitemap.map (each => sites[each.slug] = each)
+
+    var dot = ['node [shape=box style=filled fillcolor=lightgray]','rankdir=LR']
+    var page = await get(`http://${site}/${slug}.json`)
+    const links = /\[\[(.+?)\]\]/g
+    while(more = links.exec(page.story[1].text)) {
+      let title = more[1]
+      console.log('title',title)
+      dot.push(node(title,'bisque'))
+      if(sites[asSlug(title)]) {
+        let page2 = await get(`http://growing.bay.wiki.org/${asSlug(title)}.json`)
+        for (var i = 0; i<page2.story.length; i++) {
+          let text2 = page2.story[i].text
+          const links2 = /\[\[(.+?)\]\]/g
+          if (text2.match(/^When /)) {
+            while(more2 = links2.exec(text2)) {
+              console.log('when',more2[1])
+              dot.push(node(more2[1],'lightblue'))
+              dot.push(`${quote(more2[1])} -> ${quote(title)}`)
+            }
+          }
+          if (text2.match(/^Then /)) {
+            while(more2 = links2.exec(text2)) {
+              console.log('then',more2[1])
+              dot.push(node(more2[1],'lightblue'))
+              dot.push(`${quote(title)} -> ${quote(more2[1])}`)
+            }
+          }
+        }
+      } else {
+        dot.push(`${quote('pre-'+title+'-one')} -> ${quote(title)}`)
+        dot.push(`${quote(title)} -> ${quote('post-'+title+'-one')}`)
+        dot.push(`${quote('pre-'+title+'-two')} -> ${quote(title)}`)
+        dot.push(`${quote(title)} -> ${quote('post-'+title+'-two')}`)
+      }
+    }
+    return `strict digraph {\n${dot.join("\n")}\n}`
+  }
+
+
   emit = ($item, item) => {
     return $item.append(`
-    <div data-item="viewer" style="width:98%">
-    <graphviz-viewer>${expand(item.text)}</graphviz-viewer>
+    <div class="viewer" data-item="viewer" style="width:98%">
     </div>`)
   };
 
@@ -24,14 +74,16 @@
     $item.dblclick(() => {
       return wiki.textEditor($item, item);
     });
-    let viewer = $item.find('graphviz-viewer')
-    viewer.dblclick(event => {
-      if(event.shiftKey) {
-        event.stopPropagation()
-        wiki.dialog('Graphviz', `<div><graphviz-viewer>${expand(item.text)}</graphviz-viewer></div>`)
-      }
-    })
-    viewer.get(0).render().then(svg => {
+    let dot = await diagram($item, item)
+    $item.find('.viewer').html(`<graphviz-viewer>${dot}</graphviz-viewer>`)
+    let $viewer = $item.find('graphviz-viewer')
+    // $viewer.dblclick(event => {
+    //   if(event.shiftKey) {
+    //     event.stopPropagation()
+    //     wiki.dialog('Graphviz', `<div><graphviz-viewer>${expand(item.text)}</graphviz-viewer></div>`)
+    //   }
+    // })
+    $viewer.get(0).render().then(svg => {
       $(svg).find('.node').click((event)=> {
         event.stopPropagation()
         event.preventDefault()

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -118,6 +118,9 @@
   emit = ($item, item) => {
     return $item.append(`
     <div class="viewer" data-item="viewer" style="width:98%">
+      <div style="width:80%; padding:8px; color:gray; background-color:#eee; margin:0 auto; text-align:center">
+        <i>loading diagram</i>
+      </div>
     </div>`)
   };
 

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -75,6 +75,7 @@
       while (pc < tree.length) {
         let ir = tree[pc++]
         const nest = () => (pc < tree.length && Array.isArray(tree[pc])) ? tree[pc++] : []
+        const peek = (keyword) => pc < tree.length && tree[pc]==keyword && pc++
 
         if (Array.isArray(ir)) {
           deeper.push({tree:ir, context})
@@ -112,6 +113,12 @@
                 dot.push(`${quote(ir)} -> ${quote(context.name)} [style=dotted]`)
               }
               deeper.push({tree, context:Object.assign({},context,{page, want:page.story})})
+            }
+            if (peek('ELSE')) {
+              let tree = nest()
+              if (!page) {
+                deeper.push({tree, context})
+              }
             }
           }
 

--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -54,9 +54,11 @@
       tree.map ((e) => {
         if (Array.isArray(e)) {
           eval(e, dot)
-        } else {
+        } else if (e.match(/^[A-Z]/)) {
           dot.push(`${parent} -> ${quote(e)}`)
           dot.push(quote(e))
+        } else {
+          dot.push(e)
         }
       })
       return dot

--- a/index.html
+++ b/index.html
@@ -1,0 +1,3 @@
+<!-- we load this js file here where we can get syntax errors in the console -->
+<!-- usage: open index.html -->
+<script src="client/graphviz.js"></script>

--- a/pages/about-graphviz-plugin
+++ b/pages/about-graphviz-plugin
@@ -1,37 +1,114 @@
 {
   "title": "About Graphviz Plugin",
   "story": [
-  {
-    "type": "paragraph",
-    "id": "eedd14de0c0f8279",
-    "text": "This plugin renders Graphviz 'dot' markup client-side using the viz.js implementation. [https://graphviz.gitlab.io/_pages/doc/info/lang.html manual]"
-  },
-  {
-    "type": "graphviz",
-    "id": "240260e8007029c0",
-    "text": "digraph {\n\"Welcome Visitors\"->\"Recent Changes\"\n\"Welcome Visitors\"->\"Local Changes\"\n}"
-  }
-],
-  "journal": [
-  {
-    "type": "create",
-    "item": {
-      "title": "About Graphviz Plugin",
-      "story": [
-  {
-    "type": "paragraph",
-    "id": "eedd14de0c0f8279",
-    "text": "This plugin renders Graphviz's dot markup client-side using the viz.js implementation. [https://graphviz.gitlab.io/_pages/doc/info/lang.html manual]"
-  },
-  {
-    "type": "graphviz",
-    "id": "240260e8007029c0",
-    "text": "digraph {\n\"Welcome Visitors\"->\"Recent Changes\"\n\"Welcome Visitors\"->\"Local Changes\"\n}"
-  }
-]
+    {
+      "type": "paragraph",
+      "id": "eedd14de0c0f8279",
+      "text": "This plugin renders Graphviz 'dot' markup client-side using the viz.js implementation. [https://graphviz.gitlab.io/_pages/doc/info/lang.html manual]"
     },
-    "date": 1546029410000,
-    "certificate": "from mkplugin.sh"
-  }
-]
+    {
+      "type": "graphviz",
+      "id": "240260e8007029c0",
+      "text": "digraph {\n\"Welcome Visitors\"->\"Recent Changes\"\n\"Welcome Visitors\"->\"Local Changes\"\n}"
+    },
+    {
+      "type": "paragraph",
+      "id": "6e56dc12417eb20d",
+      "text": "Common practice is to explore the Graphviz sample gallery for ideas and then examine the the source used to generate features found useful. [http://graphviz.org/gallery/ gallery]"
+    },
+    {
+      "type": "paragraph",
+      "id": "80cc5dff781eba3c",
+      "text": "We support the algorithmic generation of diagrams based on the traversal of wiki sites. For this we intersperse dot language parameters for shapes and colors with all-caps keywords that read and translate wiki pages."
+    },
+    {
+      "type": "paragraph",
+      "id": "c64dde6939acbd3b",
+      "text": "See [[Graphviz Markup Semantics]]"
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "About Graphviz Plugin",
+        "story": [
+          {
+            "type": "paragraph",
+            "id": "eedd14de0c0f8279",
+            "text": "This plugin renders Graphviz's dot markup client-side using the viz.js implementation. [https://graphviz.gitlab.io/_pages/doc/info/lang.html manual]"
+          },
+          {
+            "type": "graphviz",
+            "id": "240260e8007029c0",
+            "text": "digraph {\n\"Welcome Visitors\"->\"Recent Changes\"\n\"Welcome Visitors\"->\"Local Changes\"\n}"
+          }
+        ]
+      },
+      "date": 1546029410000,
+      "certificate": "from mkplugin.sh"
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "6e56dc12417eb20d"
+      },
+      "id": "6e56dc12417eb20d",
+      "type": "add",
+      "after": "240260e8007029c0",
+      "date": 1551847768683
+    },
+    {
+      "type": "edit",
+      "id": "6e56dc12417eb20d",
+      "item": {
+        "type": "paragraph",
+        "id": "6e56dc12417eb20d",
+        "text": "Common practice is to explore the Graphviz sample gallery for ideas and then examine the the source used to generate features found useful."
+      },
+      "date": 1551847919699
+    },
+    {
+      "type": "edit",
+      "id": "6e56dc12417eb20d",
+      "item": {
+        "type": "paragraph",
+        "id": "6e56dc12417eb20d",
+        "text": "Common practice is to explore the Graphviz sample gallery for ideas and then examine the the source used to generate features found useful. [http://graphviz.org/gallery/ gallery]"
+      },
+      "date": 1551847956295
+    },
+    {
+      "type": "add",
+      "id": "80cc5dff781eba3c",
+      "item": {
+        "type": "paragraph",
+        "id": "80cc5dff781eba3c",
+        "text": "We support the algorithmic generation of diagrams based on the traversal of wiki sites. For this we intersperse dot language parameters for shapes and colors with all-caps keywords that read and translate wiki pages. See [[Graphviz Markup Semantics]]"
+      },
+      "after": "6e56dc12417eb20d",
+      "date": 1551848784401
+    },
+    {
+      "type": "edit",
+      "id": "80cc5dff781eba3c",
+      "item": {
+        "type": "paragraph",
+        "id": "80cc5dff781eba3c",
+        "text": "We support the algorithmic generation of diagrams based on the traversal of wiki sites. For this we intersperse dot language parameters for shapes and colors with all-caps keywords that read and translate wiki pages."
+      },
+      "date": 1551848792682
+    },
+    {
+      "type": "add",
+      "id": "c64dde6939acbd3b",
+      "item": {
+        "type": "paragraph",
+        "id": "c64dde6939acbd3b",
+        "text": "See [[Graphviz Markup Semantics]]"
+      },
+      "after": "80cc5dff781eba3c",
+      "date": 1551848794479
+    }
+  ]
 }

--- a/pages/graphviz-markup-semantics
+++ b/pages/graphviz-markup-semantics
@@ -1,0 +1,767 @@
+{
+  "title": "Graphviz Markup Semantics",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "5048fa12ac0cc8b7",
+      "text": "We define what happens when markup keywords are encountered by the breadth-first evaluator. See [[Extract Site to Dot]] for examples."
+    },
+    {
+      "type": "markdown",
+      "id": "72ff85d728dd4fd0",
+      "text": "# Context"
+    },
+    {
+      "type": "paragraph",
+      "id": "c9fb2d4b767258a4",
+      "text": "Context is established by keywords, used in place and passed as a copy to nested markup."
+    },
+    {
+      "type": "paragraph",
+      "id": "5916f9f362b95f18",
+      "text": "Keywords that establish a page title, a name in context, do not immediately fetch that page."
+    },
+    {
+      "type": "paragraph",
+      "id": "a6e1009c05859fa1",
+      "text": "Keywords that successfully fetch pages establish that content as the page in context for nested markup."
+    },
+    {
+      "type": "paragraph",
+      "id": "9d5a6ab14f820d6a",
+      "text": "Keywords can subset the page in context and pass that to nested markup."
+    },
+    {
+      "type": "paragraph",
+      "id": "1d4be3cad3a1850d",
+      "text": "Lines without keywords will pass through as is.  [https://graphviz.gitlab.io/_pages/doc/info/lang.html dot]"
+    },
+    {
+      "type": "markdown",
+      "id": "2862f373c7cfce5c",
+      "text": "# Keywords"
+    },
+    {
+      "type": "paragraph",
+      "id": "aa81845f4df55fac",
+      "text": "DOT digraph"
+    },
+    {
+      "type": "paragraph",
+      "id": "ea6116b10bab4c29",
+      "text": "DOT strict digraph"
+    },
+    {
+      "type": "paragraph",
+      "id": "c23a1a269be94fca",
+      "text": "Engage the algorithmic translation of linked wiki pages using the following additional keywords. We support the two dot variations shown."
+    },
+    {
+      "type": "paragraph",
+      "id": "ddc67b912a5f992c",
+      "text": "HERE"
+    },
+    {
+      "type": "paragraph",
+      "id": "0fa5e911c6ecf064",
+      "text": "HERE NODE"
+    },
+    {
+      "type": "paragraph",
+      "id": "fb81d124b0374f8b",
+      "text": "HERE NODE label"
+    },
+    {
+      "type": "paragraph",
+      "id": "9a5dd9aedca84506",
+      "text": "The name in context is established as a page to be examined. A fetch is initiated. The page becomes the page in context. Optionally render as node. Optionally render the labeled markup node with a dotted edge to node here."
+    },
+    {
+      "type": "paragraph",
+      "id": "536f6fe3aeff96e5",
+      "text": "LINK"
+    },
+    {
+      "type": "paragraph",
+      "id": "e2e98882fb07b46e",
+      "text": "LINK HERE -> NODE"
+    },
+    {
+      "type": "paragraph",
+      "id": "36deb4964baa5344",
+      "text": "LINK NODE -> HERE"
+    },
+    {
+      "type": "paragraph",
+      "id": "ce8fc80833ef13e2",
+      "text": "The page in context or WHERE-portions thereof are examined for internal links. These become the name in context for nested markup. Optionally render an edge from/to the page in context to/from each new name in context."
+    },
+    {
+      "type": "paragraph",
+      "id": "a49298c7ab3f2918",
+      "text": "WHERE /reg-ex/"
+    },
+    {
+      "type": "paragraph",
+      "id": "ddd9a8875592ee97",
+      "text": "WHERE graph"
+    },
+    {
+      "type": "paragraph",
+      "id": "2cee4fbba57d8a2c",
+      "text": "The page in context is examined for items matching a condition which become the subset page in context for nested markup."
+    },
+    {
+      "type": "paragraph",
+      "id": "499b8eddb32a7b96",
+      "text": "ELSE"
+    },
+    {
+      "type": "paragraph",
+      "id": "136a724d0c84d8c5",
+      "text": "When the preceding HERE fails to retrieve and establish a page in context then nested markup is evaluated with the previous context in place."
+    },
+    {
+      "type": "paragraph",
+      "id": "e3f86adebe0742df",
+      "text": "FAKE NODE -> HERE"
+    },
+    {
+      "type": "paragraph",
+      "id": "1dd94e53aa04e2a0",
+      "text": "FAKE HERE -> NODE"
+    },
+    {
+      "type": "paragraph",
+      "id": "593e6afec586a37c",
+      "text": "Render an edge from/to the name in context (failed page in context) to/from a fabricated node name based on adding a prefix (pre or post) and an occurrence name (one, two or three) to the name in context."
+    },
+    {
+      "type": "paragraph",
+      "id": "32bd81e743c795e2",
+      "text": "LINEUP"
+    },
+    {
+      "type": "paragraph",
+      "id": "64922df19d0f0ceb",
+      "text": "The site and slug of leftward lineup pages become the name in context for nested markup. "
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Graphviz Markup Semantics",
+        "story": []
+      },
+      "date": 1551662925921
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "5048fa12ac0cc8b7"
+      },
+      "id": "5048fa12ac0cc8b7",
+      "type": "add",
+      "date": 1551662928431
+    },
+    {
+      "type": "edit",
+      "id": "5048fa12ac0cc8b7",
+      "item": {
+        "type": "paragraph",
+        "id": "5048fa12ac0cc8b7",
+        "text": "We define what happens when markup keywords are encountered by the breadth-first evaluator. See [[Extract Site to Dot]] for examples."
+      },
+      "date": 1551663025544
+    },
+    {
+      "type": "add",
+      "id": "ddc67b912a5f992c",
+      "item": {
+        "type": "paragraph",
+        "id": "ddc67b912a5f992c",
+        "text": "# HERE"
+      },
+      "after": "5048fa12ac0cc8b7",
+      "date": 1551663065087
+    },
+    {
+      "type": "add",
+      "id": "9a5dd9aedca84506",
+      "item": {
+        "type": "paragraph",
+        "id": "9a5dd9aedca84506",
+        "text": "The name in context is established as a page to be examined. A fetch is initiated. The page becomes the page in context."
+      },
+      "after": "ddc67b912a5f992c",
+      "date": 1551663335830
+    },
+    {
+      "type": "edit",
+      "id": "ddc67b912a5f992c",
+      "item": {
+        "type": "paragraph",
+        "id": "ddc67b912a5f992c",
+        "text": "HERE"
+      },
+      "date": 1551663344797
+    },
+    {
+      "type": "add",
+      "id": "536f6fe3aeff96e5",
+      "item": {
+        "type": "paragraph",
+        "id": "536f6fe3aeff96e5",
+        "text": "LINK"
+      },
+      "after": "9a5dd9aedca84506",
+      "date": 1551663509288
+    },
+    {
+      "type": "add",
+      "id": "ce8fc80833ef13e2",
+      "item": {
+        "type": "paragraph",
+        "id": "ce8fc80833ef13e2",
+        "text": "The page in context or WHERE-portions thereof are examined for internal links. These become the name in context for nested markup."
+      },
+      "after": "536f6fe3aeff96e5",
+      "date": 1551663777962
+    },
+    {
+      "type": "add",
+      "id": "a49298c7ab3f2918",
+      "item": {
+        "type": "paragraph",
+        "id": "a49298c7ab3f2918",
+        "text": "WHERE condition"
+      },
+      "after": "ce8fc80833ef13e2",
+      "date": 1551664009795
+    },
+    {
+      "type": "add",
+      "id": "2cee4fbba57d8a2c",
+      "item": {
+        "type": "paragraph",
+        "id": "2cee4fbba57d8a2c",
+        "text": "The page in context is examined for items matching a condition which become the subset page in context for nested markup."
+      },
+      "after": "a49298c7ab3f2918",
+      "date": 1551664226126
+    },
+    {
+      "type": "add",
+      "id": "499b8eddb32a7b96",
+      "item": {
+        "type": "paragraph",
+        "id": "499b8eddb32a7b96",
+        "text": "NODE"
+      },
+      "after": "2cee4fbba57d8a2c",
+      "date": 1551664563502
+    },
+    {
+      "type": "add",
+      "id": "5572a1d11801fd8f",
+      "item": {
+        "type": "paragraph",
+        "id": "5572a1d11801fd8f",
+        "text": "LINK HERE"
+      },
+      "after": "536f6fe3aeff96e5",
+      "date": 1551665113672
+    },
+    {
+      "type": "remove",
+      "id": "5572a1d11801fd8f",
+      "date": 1551665167562
+    },
+    {
+      "type": "add",
+      "id": "36deb4964baa5344",
+      "item": {
+        "type": "paragraph",
+        "id": "36deb4964baa5344",
+        "text": "LINK NODE -> HERE"
+      },
+      "after": "536f6fe3aeff96e5",
+      "date": 1551665258496
+    },
+    {
+      "type": "add",
+      "id": "e2e98882fb07b46e",
+      "item": {
+        "type": "paragraph",
+        "id": "e2e98882fb07b46e",
+        "text": "LINK HERE -> NODE"
+      },
+      "after": "36deb4964baa5344",
+      "date": 1551665271810
+    },
+    {
+      "type": "add",
+      "id": "438a8de03a8e8d1c",
+      "item": {
+        "type": "paragraph",
+        "id": "438a8de03a8e8d1c",
+        "text": "Optionally relate the page in context to each new name in context with a forward or backward arc."
+      },
+      "after": "ce8fc80833ef13e2",
+      "date": 1551665748571
+    },
+    {
+      "type": "remove",
+      "id": "438a8de03a8e8d1c",
+      "date": 1551665756259
+    },
+    {
+      "type": "edit",
+      "id": "ce8fc80833ef13e2",
+      "item": {
+        "type": "paragraph",
+        "id": "ce8fc80833ef13e2",
+        "text": "The page in context or WHERE-portions thereof are examined for internal links. These become the name in context for nested markup. Optionally relate the page in context to each new name in context with a forward or backward arc."
+      },
+      "date": 1551665758602
+    },
+    {
+      "type": "move",
+      "order": [
+        "5048fa12ac0cc8b7",
+        "ddc67b912a5f992c",
+        "9a5dd9aedca84506",
+        "536f6fe3aeff96e5",
+        "e2e98882fb07b46e",
+        "36deb4964baa5344",
+        "ce8fc80833ef13e2",
+        "a49298c7ab3f2918",
+        "2cee4fbba57d8a2c",
+        "499b8eddb32a7b96"
+      ],
+      "id": "e2e98882fb07b46e",
+      "date": 1551665766578
+    },
+    {
+      "type": "edit",
+      "id": "a49298c7ab3f2918",
+      "item": {
+        "type": "paragraph",
+        "id": "a49298c7ab3f2918",
+        "text": "WHERE /reg-ex/"
+      },
+      "date": 1551665849350
+    },
+    {
+      "type": "add",
+      "id": "ddd9a8875592ee97",
+      "item": {
+        "type": "paragraph",
+        "id": "ddd9a8875592ee97",
+        "text": "WHERE graph"
+      },
+      "after": "a49298c7ab3f2918",
+      "date": 1551665859496
+    },
+    {
+      "type": "edit",
+      "id": "499b8eddb32a7b96",
+      "item": {
+        "type": "paragraph",
+        "id": "499b8eddb32a7b96",
+        "text": "ELSE"
+      },
+      "date": 1551665996010
+    },
+    {
+      "type": "add",
+      "id": "136a724d0c84d8c5",
+      "item": {
+        "type": "paragraph",
+        "id": "136a724d0c84d8c5",
+        "text": "When "
+      },
+      "after": "499b8eddb32a7b96",
+      "date": 1551666091826
+    },
+    {
+      "type": "edit",
+      "id": "136a724d0c84d8c5",
+      "item": {
+        "type": "paragraph",
+        "id": "136a724d0c84d8c5",
+        "text": "When the preceding HERE fails to retrieve and establish a page in context then nested markup evaluated with the previous context in place."
+      },
+      "date": 1551666337570
+    },
+    {
+      "type": "add",
+      "id": "1dd94e53aa04e2a0",
+      "item": {
+        "type": "paragraph",
+        "id": "1dd94e53aa04e2a0",
+        "text": "FAKE HERE -> NODE"
+      },
+      "after": "136a724d0c84d8c5",
+      "date": 1551666368938
+    },
+    {
+      "type": "add",
+      "id": "e3f86adebe0742df",
+      "item": {
+        "type": "paragraph",
+        "id": "e3f86adebe0742df",
+        "text": "FAKE NODE -> HERE"
+      },
+      "after": "1dd94e53aa04e2a0",
+      "date": 1551666383728
+    },
+    {
+      "type": "edit",
+      "id": "136a724d0c84d8c5",
+      "item": {
+        "type": "paragraph",
+        "id": "136a724d0c84d8c5",
+        "text": "When the preceding HERE fails to retrieve and establish a page in context then nested markup is evaluated with the previous context in place."
+      },
+      "date": 1551666436015
+    },
+    {
+      "type": "add",
+      "id": "593e6afec586a37c",
+      "item": {
+        "type": "paragraph",
+        "id": "593e6afec586a37c",
+        "text": "Relate the name in context (failed page in context) to a fabricated node name based on adding a prefix (pre or post) and an occurrence name (one, two or three) to the name in context."
+      },
+      "after": "e3f86adebe0742df",
+      "date": 1551666705030
+    },
+    {
+      "type": "move",
+      "order": [
+        "5048fa12ac0cc8b7",
+        "ddc67b912a5f992c",
+        "9a5dd9aedca84506",
+        "536f6fe3aeff96e5",
+        "e2e98882fb07b46e",
+        "36deb4964baa5344",
+        "ce8fc80833ef13e2",
+        "a49298c7ab3f2918",
+        "ddd9a8875592ee97",
+        "2cee4fbba57d8a2c",
+        "499b8eddb32a7b96",
+        "136a724d0c84d8c5",
+        "e3f86adebe0742df",
+        "1dd94e53aa04e2a0",
+        "593e6afec586a37c"
+      ],
+      "id": "e3f86adebe0742df",
+      "date": 1551666728360
+    },
+    {
+      "type": "add",
+      "id": "32bd81e743c795e2",
+      "item": {
+        "type": "paragraph",
+        "id": "32bd81e743c795e2",
+        "text": "LINEUP"
+      },
+      "after": "593e6afec586a37c",
+      "date": 1551666864826
+    },
+    {
+      "type": "add",
+      "id": "64922df19d0f0ceb",
+      "item": {
+        "type": "paragraph",
+        "id": "64922df19d0f0ceb",
+        "text": "The site and slug of leftward lineup pages become the name in context for nested markup. "
+      },
+      "after": "32bd81e743c795e2",
+      "date": 1551667188610
+    },
+    {
+      "type": "add",
+      "id": "72ff85d728dd4fd0",
+      "item": {
+        "type": "paragraph",
+        "id": "72ff85d728dd4fd0",
+        "text": "# Context"
+      },
+      "after": "5048fa12ac0cc8b7",
+      "date": 1551667228097
+    },
+    {
+      "type": "add",
+      "id": "c9fb2d4b767258a4",
+      "item": {
+        "type": "paragraph",
+        "id": "c9fb2d4b767258a4",
+        "text": "Context is established by keywords, used in place and passed as a copy to nested markup."
+      },
+      "after": "72ff85d728dd4fd0",
+      "date": 1551667414947
+    },
+    {
+      "type": "add",
+      "id": "5916f9f362b95f18",
+      "item": {
+        "type": "paragraph",
+        "id": "5916f9f362b95f18",
+        "text": "Keywords that establish a page title, a name in context, do not immediately fetch that page. Keywords that successfully fetch pages establish that content as the page in context."
+      },
+      "after": "c9fb2d4b767258a4",
+      "date": 1551667659619
+    },
+    {
+      "type": "edit",
+      "id": "72ff85d728dd4fd0",
+      "item": {
+        "type": "markdown",
+        "id": "72ff85d728dd4fd0",
+        "text": "# Context"
+      },
+      "date": 1551667666723
+    },
+    {
+      "type": "edit",
+      "id": "5916f9f362b95f18",
+      "item": {
+        "type": "paragraph",
+        "id": "5916f9f362b95f18",
+        "text": "Keywords that establish a page title, a name in context, do not immediately fetch that page."
+      },
+      "date": 1551667673027
+    },
+    {
+      "type": "add",
+      "id": "a6e1009c05859fa1",
+      "item": {
+        "type": "paragraph",
+        "id": "a6e1009c05859fa1",
+        "text": "Keywords that successfully fetch pages establish that content as the page in context."
+      },
+      "after": "5916f9f362b95f18",
+      "date": 1551667674578
+    },
+    {
+      "type": "add",
+      "id": "2862f373c7cfce5c",
+      "item": {
+        "type": "paragraph",
+        "id": "2862f373c7cfce5c",
+        "text": "# Keywords"
+      },
+      "after": "a6e1009c05859fa1",
+      "date": 1551667684725
+    },
+    {
+      "type": "edit",
+      "id": "2862f373c7cfce5c",
+      "item": {
+        "type": "markdown",
+        "id": "2862f373c7cfce5c",
+        "text": "# Keywords"
+      },
+      "date": 1551667687113
+    },
+    {
+      "type": "add",
+      "id": "9d5a6ab14f820d6a",
+      "item": {
+        "type": "paragraph",
+        "id": "9d5a6ab14f820d6a",
+        "text": "Keywords can subset the page in context and pass that to nested markup."
+      },
+      "after": "a6e1009c05859fa1",
+      "date": 1551667771445
+    },
+    {
+      "type": "edit",
+      "id": "a6e1009c05859fa1",
+      "item": {
+        "type": "paragraph",
+        "id": "a6e1009c05859fa1",
+        "text": "Keywords that successfully fetch pages establish that content as the page in context for nested markup."
+      },
+      "date": 1551667795833
+    },
+    {
+      "type": "add",
+      "id": "0fa5e911c6ecf064",
+      "item": {
+        "type": "paragraph",
+        "id": "0fa5e911c6ecf064",
+        "text": "HERE NODE"
+      },
+      "after": "ddc67b912a5f992c",
+      "date": 1551798708492
+    },
+    {
+      "type": "edit",
+      "id": "9a5dd9aedca84506",
+      "item": {
+        "type": "paragraph",
+        "id": "9a5dd9aedca84506",
+        "text": "The name in context is established as a page to be examined. A fetch is initiated. The page becomes the page in context. Optionally render as node."
+      },
+      "date": 1551798805426
+    },
+    {
+      "type": "edit",
+      "id": "ce8fc80833ef13e2",
+      "item": {
+        "type": "paragraph",
+        "id": "ce8fc80833ef13e2",
+        "text": "The page in context or WHERE-portions thereof are examined for internal links. These become the name in context for nested markup. Optionally render arc from/to the page in context to/from each new name in context."
+      },
+      "date": 1551798910808
+    },
+    {
+      "type": "edit",
+      "id": "593e6afec586a37c",
+      "item": {
+        "type": "paragraph",
+        "id": "593e6afec586a37c",
+        "text": "Render an arc from/to the name in context (failed page in context) to/from a fabricated node name based on adding a prefix (pre or post) and an occurrence name (one, two or three) to the name in context."
+      },
+      "date": 1551798968485
+    },
+    {
+      "type": "edit",
+      "id": "ce8fc80833ef13e2",
+      "item": {
+        "type": "paragraph",
+        "id": "ce8fc80833ef13e2",
+        "text": "The page in context or WHERE-portions thereof are examined for internal links. These become the name in context for nested markup. Optionally render an edge from/to the page in context to/from each new name in context."
+      },
+      "date": 1551799122044
+    },
+    {
+      "type": "edit",
+      "id": "593e6afec586a37c",
+      "item": {
+        "type": "paragraph",
+        "id": "593e6afec586a37c",
+        "text": "Render an edge from/to the name in context (failed page in context) to/from a fabricated node name based on adding a prefix (pre or post) and an occurrence name (one, two or three) to the name in context."
+      },
+      "date": 1551799131880
+    },
+    {
+      "type": "add",
+      "id": "1d4be3cad3a1850d",
+      "item": {
+        "type": "paragraph",
+        "id": "1d4be3cad3a1850d",
+        "text": "Lines without keywords will pass through as dot. [https://graphviz.gitlab.io/_pages/doc/info/lang.html graphviz]"
+      },
+      "after": "9d5a6ab14f820d6a",
+      "date": 1551808218559
+    },
+    {
+      "type": "edit",
+      "id": "1d4be3cad3a1850d",
+      "item": {
+        "type": "paragraph",
+        "id": "1d4be3cad3a1850d",
+        "text": "Lines without keywords will pass through as is.  [https://graphviz.gitlab.io/_pages/doc/info/lang.html dot]"
+      },
+      "date": 1551808268547
+    },
+    {
+      "type": "add",
+      "id": "fb81d124b0374f8b",
+      "item": {
+        "type": "paragraph",
+        "id": "fb81d124b0374f8b",
+        "text": "HERE NODE label"
+      },
+      "after": "0fa5e911c6ecf064",
+      "date": 1551829777118
+    },
+    {
+      "type": "edit",
+      "id": "9a5dd9aedca84506",
+      "item": {
+        "type": "paragraph",
+        "id": "9a5dd9aedca84506",
+        "text": "The name in context is established as a page to be examined. A fetch is initiated. The page becomes the page in context. Optionally render as node. Optionally render the labeled markup node with a dotted edge to node here."
+      },
+      "date": 1551829851455
+    },
+    {
+      "type": "add",
+      "id": "aa81845f4df55fac",
+      "item": {
+        "type": "paragraph",
+        "id": "aa81845f4df55fac",
+        "text": "DOT digraph"
+      },
+      "after": "1d4be3cad3a1850d",
+      "date": 1551848260071
+    },
+    {
+      "type": "move",
+      "order": [
+        "5048fa12ac0cc8b7",
+        "72ff85d728dd4fd0",
+        "c9fb2d4b767258a4",
+        "5916f9f362b95f18",
+        "a6e1009c05859fa1",
+        "9d5a6ab14f820d6a",
+        "1d4be3cad3a1850d",
+        "2862f373c7cfce5c",
+        "aa81845f4df55fac",
+        "ddc67b912a5f992c",
+        "0fa5e911c6ecf064",
+        "fb81d124b0374f8b",
+        "9a5dd9aedca84506",
+        "536f6fe3aeff96e5",
+        "e2e98882fb07b46e",
+        "36deb4964baa5344",
+        "ce8fc80833ef13e2",
+        "a49298c7ab3f2918",
+        "ddd9a8875592ee97",
+        "2cee4fbba57d8a2c",
+        "499b8eddb32a7b96",
+        "136a724d0c84d8c5",
+        "e3f86adebe0742df",
+        "1dd94e53aa04e2a0",
+        "593e6afec586a37c",
+        "32bd81e743c795e2",
+        "64922df19d0f0ceb"
+      ],
+      "id": "aa81845f4df55fac",
+      "date": 1551848265859
+    },
+    {
+      "type": "add",
+      "id": "ea6116b10bab4c29",
+      "item": {
+        "type": "paragraph",
+        "id": "ea6116b10bab4c29",
+        "text": "DOT strict digraph"
+      },
+      "after": "aa81845f4df55fac",
+      "date": 1551848282640
+    },
+    {
+      "type": "add",
+      "id": "c23a1a269be94fca",
+      "item": {
+        "type": "paragraph",
+        "id": "c23a1a269be94fca",
+        "text": "Engage the algorithmic translation of linked wiki pages using the following additional keywords. We support the two dot variations shown."
+      },
+      "after": "ea6116b10bab4c29",
+      "date": 1551848500191
+    },
+    {
+      "type": "fork",
+      "site": "ward.asia.wiki.org",
+      "date": 1551848565370
+    }
+  ]
+}


### PR DESCRIPTION
This pull request implements the markup keywords described here:
http://ward.asia.wiki.org/graphviz-markup-semantics.html

Each keyword has been shown to work as expected although there are design decisions who's consequences might not be fully anticipated. We won't understand the full impact of each until we use this with large and varied sites.

We have not yet engaged the Collaborative Link or achieved the full async fetch behavior we desire. We have preserved the experimental `DOT MEHAFFY` markup to use as a reference at least for a while. We might ultimately replace its javascript with algorithmic markup or discard the feature without notice.

Expect draft about pages to be included here later this evening.

Here we compare this code on the left and our original javascript implementation on the right.

![image](https://user-images.githubusercontent.com/12127/53855879-67ba3400-3f84-11e9-9cc9-d177b59784ce.png)

This is the markup I used. Notice that the first HERE, the parent of all the beige nodes, is not drawn in this diagram because the NODE  parameter is omitted in the first HERE. The fillcolor=white would color it if it were. The same goes for following links but not drawing them with the first LINKS keyword. 
```
DOT digraph
  rankdir=LR
  node [shape=box style=filled fillcolor=white]
  HERE
    LINKS
      node [fillcolor=bisque]
      HERE NODE
        WHERE /^When/
          node [fillcolor=lightblue]
          LINKS NODE -> HERE
        WHERE /^Then/
          LINKS HERE -> NODE
```