### PR TITLE
set context for doInternalLink

### DIFF
--- a/client/graphviz.js
+++ b/client/graphviz.js
@@ -481,6 +481,8 @@ ${item.dot??''}`
             let $page = event.shiftKey ? null : $item.parents('.page')
             if (title) {
               console.log('click', title)
+              // set context for doInternalLink
+              wiki.pageHandler.context = wiki.lineup.atKey($page.data('key')).getContext()
               wiki.doInternalLink(title, $page)
             }
           }


### PR DESCRIPTION
Set the context for the internal link before calling `doInternalLink`

This mimics the click handler for internal links - see [wiki-client - legacy.coffee lines 178-184](https://github.com/fedwiki/wiki-client/blob/9ab91291c067bf09f77ba3d51dd3c8e7549b4bfd/lib/legacy.coffee#L178-L184).